### PR TITLE
implement messages stream

### DIFF
--- a/server_node/routes/message.js
+++ b/server_node/routes/message.js
@@ -1,0 +1,66 @@
+var mongoose = require('mongoose')
+
+module.exports = function(app) {
+
+  app.get('/message', function (req, res, next) {
+    var isStream = (req.query.feed == 'continuous')
+      , isFirst = true
+      , sep
+
+    function ondoc(doc) {
+      try {
+        doc = JSON.stringify(doc)
+      } catch(e) {
+        console.error(e)
+        return
+      }
+
+      if (isFirst) {
+        isFirst = false
+      } else {
+        res.write(sep)
+      }
+
+      res.write(doc)
+    }
+
+
+    if (isStream) {
+      sep = '\r\n'
+      res.setHeader('Content-Type', 'application/x-json-stream')
+
+      app.on('message', ondoc)
+
+      res.on('close', function () {
+        app.removeListener('message', ondoc)
+      })
+
+    } else {
+      sep = ',\r\n'
+      res.setHeader('Content-Type', 'application/json')
+      res.write('[')
+    }
+
+
+    var query = {}
+      , since
+    if (req.query.since) {
+      try {
+        since = new mongoose.Types.ObjectId(req.query.since)
+      } catch(e) {
+        return next(new Error('Invalid ObjectID for `since` query param'))
+      }
+      query._id = { $gt: since }
+    }
+
+    var stream = app.MessageModel.find(query).stream()
+    stream.on('data', ondoc)
+
+    if (!isStream) {
+      stream.on('end', function () {
+        res.end(']')
+      })
+    }
+  })
+
+}

--- a/server_node/web.js
+++ b/server_node/web.js
@@ -41,48 +41,15 @@ var MessageSchema = new mongoose.Schema({
 
 var MessageModel = mongoose.model('message', MessageSchema);
 
-app.get('/message', function (req, res, next) {
-  if (req.query.feed != 'continuous') return next()
+app.MessageModel = MessageModel
 
-  res.setHeader('Content-Type', 'application/x-json-stream')
-
-  function ondoc(doc) {
-    try {
-      doc = JSON.stringify(doc)
-    } catch(e) {
-      console.error(e)
-      return
-    }
-
-    res.write(doc + '\r\n')
-  }
-
-  app.on('message', ondoc)
-
-  res.on('close', function () {
-    app.removeListener('message', ondoc)
-  })
-
-  var query = {}
-    , since
-  if (req.query.since) {
-    try {
-      since = new mongoose.Types.ObjectId(req.query.since)
-    } catch(e) {
-      return next(new Error('Invalid ObjectID for `since` query param'))
-    }
-    query._id = { $gt: since }
-  }
-
-  var stream = MessageModel.find(query).stream()
-  stream.on('data', ondoc)
-})
+require('./routes/message')(app)
 
 colibri.createResource(app, {
   model: MessageModel,
   hooks: {
     'post': {
-      'save': function(req, res, next) {
+      'save': function (req, res, next) {
         app.emit('message', req.rest.document)
         return next(null)
       }


### PR DESCRIPTION
Gjør det mulig å få en stream med nye meldinger. Dette er senvsagt ikke en skalerbar løsning, men siden det bare er for kurs sammenheng er det mer enn nok.

Den tar ikke høyde for `PUT` og `DELETE` endringer. Jeg tenkte på å lage en `changes` stream istedenfor som inneholder alle endringer. Men fant ut at da har vi i praksis implementert deler av CouchDB APIet i Node.JS over MongoDB.

Siden det er en blanding av 2 spaces og tabs for inrykk og kodestilen ikke er helt konsevent har jeg ikke tatt meg bryet med å følge kodestilen i filen.
